### PR TITLE
Fixed unpacking

### DIFF
--- a/ZE_CFSI_Lib/CFSI_File.cs
+++ b/ZE_CFSI_Lib/CFSI_File.cs
@@ -4,12 +4,12 @@
     {
         public string Path { get; set; } // Full path (Within archive)
         public string Name { get; set; } // File name and extension
-        public int Size { get; set; }
-        public int Offset { get; set; } // Offset relative to Data section
+        public long Size { get; set; }
+        public long Offset { get; set; } // Offset relative to Data section
         public long FileOffset { get; set; } = 0; // Absolute offset in file
         public bool Compressed { get; set; } = false;
 
-        public CFSI_File(string name, string path, int offset, int size)
+        public CFSI_File(string name, string path, long offset, long size)
         {
             Path = path;
             Name = name;

--- a/ZE_CFSI_Lib/CFSI_Lib.cs
+++ b/ZE_CFSI_Lib/CFSI_Lib.cs
@@ -28,14 +28,14 @@
             if (file.Compressed)
             {
                 stream.Position += 4;
-                MemoryStream inputStream = new(CFSI_Util.Read_ByteArray(stream, (file.Size - 4)));
+                MemoryStream inputStream = new(CFSI_Util.Read_ByteArray(stream, (int)(file.Size - 4)));
                 MemoryStream tempStream = new();
                 ICSharpCode.SharpZipLib.GZip.GZip.Decompress(inputStream, tempStream, false);
                 inputStream.Dispose();
                 inputStream.Close();
                 return tempStream.ToArray();
             }
-            return CFSI_Util.Read_ByteArray(stream, file.Size);
+            return CFSI_Util.Read_ByteArray(stream, (int)file.Size);
         }
         public void ExtractFile(CFSI_File file, string OutFolder)
         {
@@ -68,8 +68,8 @@
                 for (ushort a = 0; a < numOfFiles; a++)
                 {
                     string fileName = CFSI_Util.Read_CFSI_String(stream);
-                    int fileOffset = CFSI_Util.Read_Int32(stream) * 16;
-                    int fileSize = CFSI_Util.Read_Int32(stream);
+                    long fileOffset = CFSI_Util.Read_Unt32(stream) * 16;
+                    long fileSize = CFSI_Util.Read_Unt32(stream);
                     Files.Add(new CFSI_File(fileName, folderName + fileName, fileOffset, fileSize));
                 }
             }

--- a/ZE_CFSI_Lib/CFSI_Util.cs
+++ b/ZE_CFSI_Lib/CFSI_Util.cs
@@ -124,12 +124,21 @@ namespace ZE_CFSI_Lib
             fs.Close();
             return (int)length;
         }
+
         internal static int Read_Int32(Stream stream)
         {
             byte[] buff = new byte[4];
             stream.Read(buff, 0, buff.Length);
             return BitConverter.ToInt32(buff, 0);
         }
+
+        internal static uint Read_Unt32(Stream stream)
+        {
+            byte[] buff = new byte[4];
+            stream.Read(buff, 0, buff.Length);
+            return BitConverter.ToUInt32(buff, 0);
+        }
+
         internal static ushort Read_UInt16(Stream stream)
         {
             byte[] buff = new byte[2];


### PR DESCRIPTION
Fixed unpack some  .cfsi archives

`Extracting...
Unhandled exception. System.ArgumentOutOfRangeException: Non-negative number required. (Parameter 'value')
   at System.IO.FileStream.set_Position(Int64 value)
   at ZE_CFSI_Lib.CFSI_Lib.ReadHeader() in C:\Users\hphil\Source\Repos\ZeroEscape_CFSI_Lib\ZE_CFSI_Lib\CFSI_Lib.cs:line 84
   at ZE_CFSI_Lib.CFSI_Lib..ctor(String filePath) in C:\Users\hphil\Source\Repos\ZeroEscape_CFSI_Lib\ZE_CFSI_Lib\CFSI_Lib.cs:line 16
   at Program.Execute(String filePath) in C:\Users\hphil\Source\Repos\ZeroEscape_CFSI_Lib\ZE_CFSI_Extract\Program.cs:line 20
   at Program.Main(String[] args) in C:\Users\hphil\Source\Repos\ZeroEscape_CFSI_Lib\ZE_CFSI_Extract\Program.cs:line 30
`