### PR TITLE
Fix a bug where some CFSI files cannot be unpacked.

### DIFF
--- a/ZE_CFSI_Extract/Program.cs
+++ b/ZE_CFSI_Extract/Program.cs
@@ -44,9 +44,6 @@ public partial class Program
 
         cfsi.ExtractAll(extractPath);
 
-        string extractJsonPath = Path.ChangeExtension(filePath, ".json");
-        cfsi.ExportStructureToJson(extractJsonPath);
-
         cfsi.Dispose();
         Console.WriteLine("Extracted successfully!");
     }

--- a/ZE_CFSI_Lib/CFSI_File.cs
+++ b/ZE_CFSI_Lib/CFSI_File.cs
@@ -1,12 +1,35 @@
-﻿namespace ZE_CFSI_Lib
+using System.Text.Json.Serialization;
+
+namespace ZE_CFSI_Lib
 {
     public class CFSI_File
     {
-        public string Path { get; set; } // Full path (Within archive)
-        public string Name { get; set; } // File name and extension
+        [JsonPropertyName("path")]
+        public string Path { get; set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("size")]
         public uint Size { get; set; }
-        public uint Offset { get; set; } // Offset relative to Data section
+
+        [JsonPropertyName("offset")]
+        public uint Offset { get; set; }
+
+        [JsonPropertyName("compressed")]
         public bool Compressed { get; set; } = false;
+
+        [JsonPropertyName("originalHeaderBytes")]
+        public byte[]? OriginalHeaderBytes { get; set; }
+
+        [JsonPropertyName("originalHeaderPosition")]
+        public long OriginalHeaderPosition { get; set; }
+
+        [JsonPropertyName("originalOffsetValue")]
+        public uint OriginalOffsetValue { get; set; }
+
+        [JsonPropertyName("originalSizeValue")]
+        public uint OriginalSizeValue { get; set; }
 
         public CFSI_File(string name, string path, uint offset, uint size)
         {

--- a/ZE_CFSI_Lib/CFSI_Lib.cs
+++ b/ZE_CFSI_Lib/CFSI_Lib.cs
@@ -1,14 +1,12 @@
-using System.Text;
 using System.Text.Json;
 
 namespace ZE_CFSI_Lib
 {
-    public class CFSI_Lib : IDisposable
+    public class CFSI_Lib
     {
         public Stream stream;
         public List<CFSI_File> Files = new List<CFSI_File>();
         public long DataSectionStart = 0;
-        private bool _disposed = false;
 
         public CFSI_Lib(Stream newStream)
         {
@@ -24,21 +22,9 @@ namespace ZE_CFSI_Lib
 
         public void Dispose()
         {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!_disposed)
-            {
-                if (disposing)
-                {
-                    stream?.Dispose();
-                    Files.Clear();
-                }
-                _disposed = true;
-            }
+            stream?.Dispose();
+            stream?.Close();
+            Files.Clear();
         }
 
         public byte[] GetFileData(CFSI_File file)
@@ -48,77 +34,24 @@ namespace ZE_CFSI_Lib
 
             if (file.Compressed)
             {
-                byte[] compressedData = CFSI_Util.Read_ByteArray(stream, (int)file.Size);
+                uint uncompressedSize = CFSI_Util.Read_UInt32(stream);
+                ushort gzipSignature = CFSI_Util.Read_UInt16(stream);
 
-                if (compressedData.Length >= 2 && compressedData[0] == 0x1F && compressedData[1] == 0x8B)
+                if (gzipSignature != 0x8b1f)
                 {
-                    try
-                    {
-                        using (MemoryStream inputStream = new MemoryStream(compressedData))
-                        using (MemoryStream outputStream = new MemoryStream())
-                        {
-                            ICSharpCode.SharpZipLib.GZip.GZip.Decompress(inputStream, outputStream, false);
-                            return outputStream.ToArray();
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        throw new InvalidDataException($"GZIP decompression failed for file '{file.Name}': {ex.Message}");
-                    }
+                    throw new InvalidDataException("Invalid GZIP signature for compressed file");
                 }
-                else if (compressedData.Length >= 4)
-                {
-                    Exception? gzipEx = null;
-                    Exception? zlibEx = null;
 
-                    try
-                    {
-                        using (MemoryStream inputStream = new MemoryStream(compressedData, 4, compressedData.Length - 4))
-                        using (MemoryStream outputStream = new MemoryStream())
-                        {
-                            ICSharpCode.SharpZipLib.GZip.GZip.Decompress(inputStream, outputStream, false);
-                            return outputStream.ToArray();
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        gzipEx = ex;
-                        try
-                        {
-                            using (MemoryStream inputStream = new MemoryStream(compressedData))
-                            using (var inflaterStream = new ICSharpCode.SharpZipLib.Zip.Compression.Streams.InflaterInputStream(inputStream))
-                            using (MemoryStream outputStream = new MemoryStream())
-                            {
-                                inflaterStream.CopyTo(outputStream);
-                                return outputStream.ToArray();
-                            }
-                        }
-                        catch (Exception ex2)
-                        {
-                            zlibEx = ex2;
-                            try
-                            {
-                                using (MemoryStream inputStream = new MemoryStream(compressedData, 2, compressedData.Length - 2))
-                                using (var inflaterStream = new ICSharpCode.SharpZipLib.Zip.Compression.Streams.InflaterInputStream(inputStream))
-                                using (MemoryStream outputStream = new MemoryStream())
-                                {
-                                    inflaterStream.CopyTo(outputStream);
-                                    return outputStream.ToArray();
-                                }
-                            }
-                            catch (Exception ex3)
-                            {
-                                throw new InvalidDataException($"All decompression methods failed for file '{file.Name}'. " +
-                                    $"GZIP: {gzipEx?.Message ?? "Unknown"}, " +
-                                    $"Zlib: {zlibEx?.Message ?? "Unknown"}, " +
-                                    $"Zlib(skip2): {ex3.Message}");
-                            }
-                        }
-                    }
-                }
-                else
+                stream.Position -= 2;
+                int compressedSize = (int)(file.Size - 4);
+                byte[] compressedData = CFSI_Util.Read_ByteArray(stream, compressedSize);
+
+                using (var compressedStream = new MemoryStream(compressedData))
+                using (var gzipStream = new System.IO.Compression.GZipStream(compressedStream, System.IO.Compression.CompressionMode.Decompress))
+                using (var outputStream = new MemoryStream())
                 {
-                    throw new InvalidDataException($"Compressed data too small for file '{file.Name}': {compressedData.Length} bytes");
+                    gzipStream.CopyTo(outputStream);
+                    return outputStream.ToArray();
                 }
             }
             else
@@ -127,22 +60,92 @@ namespace ZE_CFSI_Lib
             }
         }
 
-        public void ExtractFile(CFSI_File file, string OutFolder)
+        public void ExtractFile(CFSI_File file, string outFolder)
         {
-            string outPath = Path.Combine(OutFolder, file.Path);
-            string? directoryPath = Path.GetDirectoryName(outPath);
-            if (!string.IsNullOrEmpty(directoryPath))
-            {
-                Directory.CreateDirectory(directoryPath);
-            }
-            File.WriteAllBytes(outPath, GetFileData(file));
+            string fullPath = Path.Combine(outFolder, file.Path.Replace("/", "\\"));
+            string directory = Path.GetDirectoryName(fullPath) ?? outFolder;
+
+            Directory.CreateDirectory(directory);
+
+            // Handle duplicate files
+            string actualPath = GetUniqueFilePath(fullPath);
+            File.WriteAllBytes(actualPath, GetFileData(file));
         }
 
-        public void ExtractAll(string OutFolder)
+        public void ExtractAll(string outFolder)
         {
-            if (!OutFolder.EndsWith("\\")) OutFolder += "\\";
+            if (!Directory.Exists(outFolder))
+            {
+                Directory.CreateDirectory(outFolder);
+            }
+
             foreach (CFSI_File file in Files)
-                ExtractFile(file, OutFolder);
+            {
+                ExtractFile(file, outFolder);
+            }
+
+            // Generate JSON structure file for repacking compatibility
+            GenerateStructureJson(outFolder);
+        }
+
+        private void GenerateStructureJson(string outFolder)
+        {
+            try
+            {
+                var structureInfo = new
+                {
+                    SourceCfsiFile = Path.GetFileName(stream is FileStream fs ? fs.Name : "unknown"),
+                    ExtractionDate = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"),
+                    TotalEntries = Files.Count,
+                    ExtractedEntries = Files.Count,
+                    Entries = Files.Select(f => new
+                    {
+                        FullPath = f.Path.Replace("\\", "/"),
+                        Offset = f.Offset,
+                        Size = f.Size,
+                        Extracted = true,
+                        OutputPath = Path.Combine(outFolder, f.Path.Replace("/", "\\"))
+                    }).ToArray()
+                };
+
+                string jsonFilePath = Path.Combine(Path.GetDirectoryName(outFolder) ?? outFolder,
+                    Path.GetFileName(outFolder) + ".json");
+
+                string json = JsonSerializer.Serialize(structureInfo, new JsonSerializerOptions
+                {
+                    WriteIndented = true,
+                    Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+                });
+
+                File.WriteAllText(jsonFilePath, json);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error generating JSON structure: {ex.Message}");
+            }
+        }
+
+        private string GetUniqueFilePath(string filePath)
+        {
+            if (!File.Exists(filePath))
+            {
+                return filePath;
+            }
+
+            string directory = Path.GetDirectoryName(filePath) ?? string.Empty;
+            string fileName = Path.GetFileNameWithoutExtension(filePath);
+            string extension = Path.GetExtension(filePath);
+
+            int counter = 1;
+            string newFilePath;
+
+            do
+            {
+                newFilePath = Path.Combine(directory, $"{fileName}_{counter}{extension}");
+                counter++;
+            } while (File.Exists(newFilePath));
+
+            return newFilePath;
         }
 
         private void ReadHeader()
@@ -156,7 +159,7 @@ namespace ZE_CFSI_Lib
                 string folderName = CFSI_Util.Read_CFSI_String(stream);
 
                 if (folderName.Length == 1 && folderName[0] == (char)0)
-                    folderName = "\\";
+                    folderName = "";
 
                 uint numOfFiles = CFSI_Util.Read_CFSI_VINT(stream);
 
@@ -165,279 +168,312 @@ namespace ZE_CFSI_Lib
                     string fileName = CFSI_Util.Read_CFSI_String(stream);
                     uint fileOffset = CFSI_Util.Read_UInt32(stream) * 16;
                     uint fileSize = CFSI_Util.Read_UInt32(stream);
-                    Files.Add(new CFSI_File(fileName, folderName + fileName, fileOffset, fileSize));
+
+                    string fullPath = string.IsNullOrEmpty(folderName) ? fileName : $"{folderName}/{fileName}";
+                    Files.Add(new CFSI_File(fileName, fullPath, fileOffset, fileSize));
                 }
             }
 
             DataSectionStart = CFSI_Util.CFSI_Get_Aligned(stream.Position);
 
+            // Detect compression
             foreach (var file in Files)
             {
-                if (file.Size < 2)
+                if (file.Size < 6)
                     continue;
 
                 stream.Position = DataSectionStart + file.Offset;
-
-                try
-                {
-                    byte[] header = CFSI_Util.Read_ByteArray(stream, 2);
-                    file.Compressed = (header[0] == 0x1F && header[1] == 0x8B);
-
-                    if (!file.Compressed)
-                    {
-                        file.Compressed = CFSI_Util.CFSI_ShouldBeCompressed(file.Name);
-                    }
-                }
-                catch
-                {
-                    file.Compressed = false;
-                }
+                uint uncompressedSize = CFSI_Util.Read_UInt32(stream);
+                ushort gzipSignature = CFSI_Util.Read_UInt16(stream);
+                file.Compressed = (gzipSignature == 0x8b1f);
             }
         }
 
         public static void Repack(string folder, string outPath = "")
         {
-            if (string.IsNullOrEmpty(folder))
-                throw new ArgumentNullException(nameof(folder), "Folder path cannot be null or empty");
-
             if (string.IsNullOrEmpty(outPath))
-                outPath = Path.Combine(Path.GetDirectoryName(folder) ?? "", Path.GetFileName(folder) + ".cfsi");
+                outPath = folder + ".cfsi";
 
-            folder = Path.GetFullPath(folder);
             if (!Directory.Exists(folder))
-                throw new DirectoryNotFoundException($"Source folder not found: {folder}");
+                throw new DirectoryNotFoundException($"Folder not found: {folder}");
 
-            if (!folder.EndsWith(Path.DirectorySeparatorChar.ToString()) &&
-                !folder.EndsWith(Path.AltDirectorySeparatorChar.ToString()))
+            // Try to use JSON structure file first for better compatibility
+            string jsonFilePath = Path.Combine(Path.GetDirectoryName(folder) ?? folder,
+                Path.GetFileName(folder) + ".json");
+
+            if (File.Exists(jsonFilePath))
             {
-                folder += Path.DirectorySeparatorChar;
+                RepackFromJson(folder, jsonFilePath, outPath);
             }
-
-            string originalCfsiPath = Path.Combine(Path.GetDirectoryName(folder) ?? "",
-                                                 Path.GetFileNameWithoutExtension(folder) + ".cfsi");
-
-            if (!File.Exists(originalCfsiPath))
+            else
             {
-                string altOriginalPath = folder.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + ".cfsi";
-                if (File.Exists(altOriginalPath))
-                    originalCfsiPath = altOriginalPath;
-                else
-                    throw new FileNotFoundException($"Original CFSI file not found. Tried: {originalCfsiPath} and {altOriginalPath}");
-            }
-
-            using (var originalLib = new CFSI_Lib(originalCfsiPath))
-            {
-                string? outputDir = Path.GetDirectoryName(outPath);
-                if (!string.IsNullOrEmpty(outputDir) && !Directory.Exists(outputDir))
-                {
-                    Directory.CreateDirectory(outputDir);
-                }
-
-                using (FileStream cfsiStream = new FileStream(outPath, FileMode.Create, FileAccess.Write))
-                {
-                    originalLib.stream.Seek(0, SeekOrigin.Begin);
-                    byte[] headerData = new byte[originalLib.DataSectionStart];
-                    int bytesRead = originalLib.stream.Read(headerData, 0, headerData.Length);
-                    if (bytesRead != headerData.Length)
-                        throw new IOException("Failed to read complete header data from original CFSI file");
-
-                    cfsiStream.Write(headerData, 0, bytesRead);
-
-                    long dataSection = CFSI_Util.CFSI_Get_Aligned(cfsiStream.Position);
-                    while (cfsiStream.Position < dataSection)
-                    {
-                        cfsiStream.WriteByte(0);
-                    }
-
-                    foreach (var file in originalLib.Files)
-                    {
-                        long filePosition = dataSection + file.Offset;
-                        if (filePosition < 0)
-                            throw new InvalidDataException($"Invalid file offset for {file.Path}");
-
-                        cfsiStream.Position = filePosition;
-
-                        string safeFilePath = file.Path.Replace('/', Path.DirectorySeparatorChar);
-                        string fullFilePath = Path.Combine(folder, safeFilePath);
-
-                        fullFilePath = Path.GetFullPath(fullFilePath);
-
-                        if (!File.Exists(fullFilePath))
-                        {
-                            throw new FileNotFoundException($"File not found: {fullFilePath}", fullFilePath);
-                        }
-
-                        byte[] fileData;
-                        if (file.Compressed)
-                        {
-                            using (var fs = File.OpenRead(fullFilePath))
-                            using (var compressedStream = CFSI_Util.CFSI_Get_Compressed(fs))
-                            {
-                                fileData = new byte[compressedStream.Length];
-                                compressedStream.Position = 0;
-                                int compressedBytesRead = compressedStream.Read(fileData, 0, fileData.Length);
-                                if (compressedBytesRead != fileData.Length)
-                                    throw new IOException($"Failed to read complete compressed data from {fullFilePath}");
-                            }
-                        }
-                        else
-                        {
-                            fileData = File.ReadAllBytes(fullFilePath);
-                        }
-
-                        cfsiStream.Write(fileData, 0, fileData.Length);
-
-                        long fileEnd = cfsiStream.Position;
-                        long alignedEnd = CFSI_Util.CFSI_Get_Aligned(fileEnd);
-                        while (cfsiStream.Position < alignedEnd)
-                        {
-                            cfsiStream.WriteByte(0);
-                        }
-                    }
-
-                    long fileLength = cfsiStream.Length;
-                    int remainder = (int)(fileLength % 16);
-                    if (remainder != 0)
-                    {
-                        int paddingNeeded = 16 - remainder;
-                        byte[] padding = new byte[paddingNeeded];
-                        cfsiStream.Write(padding, 0, paddingNeeded);
-                    }
-                }
+                RepackFromFolder(folder, outPath);
             }
         }
 
-        public void ExportStructureToJson(string jsonPath)
+        public static void RepackFromJson(string folder, string jsonFilePath, string outPath)
         {
-            var options = new JsonSerializerOptions
+            try
             {
-                WriteIndented = true,
-                IncludeFields = true
-            };
+                string jsonContent = File.ReadAllText(jsonFilePath);
+                var structureInfo = JsonSerializer.Deserialize<CfsiStructureInfo>(jsonContent);
 
-            stream.Seek(0, SeekOrigin.Begin);
-            byte[] fullHeader = CFSI_Util.Read_ByteArray(stream, (int)DataSectionStart);
+                if (structureInfo?.Entries == null)
+                    throw new InvalidDataException("Invalid JSON structure file");
 
-            var exportData = new
+                string extractedDir = folder;
+
+                using (var fs = new FileStream(outPath, FileMode.Create, FileAccess.Write))
+                using (var writer = new BinaryWriter(fs))
+                {
+                    var folderGroups = structureInfo.Entries
+                        .GroupBy(e => Path.GetDirectoryName(e.FullPath)?.Replace("\\", "/") ?? "")
+                        .ToList();
+
+                    WriteNum(writer, folderGroups.Count);
+
+                    foreach (var folderGroup in folderGroups)
+                    {
+                        string folderPath = folderGroup.Key;
+                        if (string.IsNullOrEmpty(folderPath))
+                        {
+                            folderPath = "";
+                        }
+                        else if (!folderPath.EndsWith("/"))
+                        {
+                            folderPath += "/";
+                        }
+
+                        WriteString(writer, folderPath);
+                        WriteNum(writer, folderGroup.Count());
+
+                        foreach (var entry in folderGroup)
+                        {
+                            string fileName = Path.GetFileName(entry.FullPath);
+                            WriteString(writer, fileName);
+
+                            uint offsetValue = entry.Offset / 0x10;
+                            writer.Write(offsetValue);
+                            writer.Write(entry.Size);
+                        }
+                    }
+
+                    long currentPos = fs.Position;
+                    long alignedPos = (currentPos + 0x0F) & ~0x0F;
+                    while (fs.Position < alignedPos)
+                    {
+                        writer.Write((byte)0);
+                    }
+
+                    long dataSectionStart = fs.Position;
+
+                    foreach (var entry in structureInfo.Entries.OrderBy(e => e.Offset))
+                    {
+                        string filePath = string.IsNullOrEmpty(entry.OutputPath)
+                            ? Path.Combine(extractedDir, entry.FullPath.Replace("/", "\\"))
+                            : entry.OutputPath;
+
+                        if (!File.Exists(filePath))
+                        {
+                            Console.WriteLine($"Warning: File not found: {filePath}");
+                            continue;
+                        }
+
+                        long filePos = dataSectionStart + entry.Offset;
+                        if (fs.Position != filePos)
+                        {
+                            fs.Position = filePos;
+                        }
+
+                        byte[] fileData = File.ReadAllBytes(filePath);
+
+                        if (entry.Size != (uint)fileData.Length)
+                        {
+                            fileData = CompressFileData(fileData);
+                        }
+
+                        writer.Write(fileData);
+
+                        long fileEnd = fs.Position;
+                        long alignedEnd = (fileEnd + 0x0F) & ~0x0F;
+                        while (fs.Position < alignedEnd)
+                        {
+                            writer.Write((byte)0);
+                        }
+                    }
+
+                    long finalPos = fs.Position;
+                    long alignedFinal = (finalPos + 0x0F) & ~0x0F;
+                    while (fs.Position < alignedFinal)
+                    {
+                        writer.Write((byte)0);
+                    }
+                }
+            }
+            catch (Exception ex)
             {
-                DataSectionStart = this.DataSectionStart,
-                Files = this.Files,
-                FullHeaderBytesBase64 = Convert.ToBase64String(fullHeader)
-            };
-
-            string json = JsonSerializer.Serialize(exportData, options);
-            File.WriteAllText(jsonPath, json);
+                Console.WriteLine($"Error repacking from JSON: {ex.Message}");
+                throw;
+            }
         }
 
-        public static void RepackFromJson(string folderPath, string jsonPath, string outPath)
+        private static void RepackFromFolder(string folder, string outPath)
         {
-            if (!Directory.Exists(folderPath))
-                throw new DirectoryNotFoundException($"Folder not found: {folderPath}");
+            if (!folder.EndsWith("\\"))
+                folder += "\\";
 
-            if (!File.Exists(jsonPath))
-                throw new FileNotFoundException($"JSON file not found: {jsonPath}");
+            string sourceDirectoryPath = Directory.GetParent(folder)?.FullName + "\\";
 
-            string jsonContent = File.ReadAllText(jsonPath);
-            var options = new JsonSerializerOptions { IncludeFields = true };
-            var structure = JsonSerializer.Deserialize<StructureData>(jsonContent, options);
-
-            if (structure == null || structure.Files == null)
-                throw new InvalidDataException("Invalid JSON structure");
-
-            using (FileStream cfsiStream = new FileStream(outPath, FileMode.Create, FileAccess.Write))
+            using (var cfsiStream = new FileStream(outPath, FileMode.Create, FileAccess.Write))
             {
-                if (!string.IsNullOrEmpty(structure.FullHeaderBytesBase64))
+                List<string> subDirectories = new List<string>();
+                List<List<string>> subDirectoriesFiles = new List<List<string>>();
+
+                var filePaths = Directory.GetFiles(folder, "*", new EnumerationOptions()
+                { RecurseSubdirectories = true })
+                    .Select(fn => fn)
+                    .OrderBy(f => CFSI_Util.CFSI_Get_FolderPath(sourceDirectoryPath, f))
+                    .ToList();
+
+                List<string> filePathsReordered = new List<string>();
+                List<long> fileOffsets = new List<long>();
+
+                foreach (var file in filePaths)
                 {
-                    byte[] fullHeaderBytes = Convert.FromBase64String(structure.FullHeaderBytesBase64);
-                    cfsiStream.Write(fullHeaderBytes, 0, fullHeaderBytes.Length);
+                    string folderPath = CFSI_Util.CFSI_Get_FolderPath(sourceDirectoryPath, file);
+
+                    if (!subDirectories.Contains(folderPath))
+                    {
+                        subDirectories.Add(folderPath);
+                        subDirectoriesFiles.Add(new List<string>());
+                    }
+                    subDirectoriesFiles[subDirectories.IndexOf(folderPath)].Add(file);
                 }
-                else
+
+                CFSI_Util.Write_CFSI_VINT(cfsiStream, (ushort)subDirectories.Count);
+
+                long relativeDataOffset = 0; 
+
+                for (int i = 0; i < subDirectories.Count; i++)
                 {
-                    RebuildHeader(cfsiStream, structure.Files);
+                    string folderPath = subDirectories[i].Replace(sourceDirectoryPath, "");
+                    if (!folderPath.EndsWith("\\") && !folderPath.EndsWith("/"))
+                    {
+                        folderPath += "/";
+                    }
+
+                    CFSI_Util.Write_CFSI_String(cfsiStream, folderPath);
+                    CFSI_Util.Write_CFSI_VINT(cfsiStream, (ushort)subDirectoriesFiles[i].Count);
+
+                    foreach (var file in subDirectoriesFiles[i])
+                    {
+                        filePathsReordered.Add(file);
+                        fileOffsets.Add(relativeDataOffset);
+
+                        CFSI_Util.Write_CFSI_String(cfsiStream,
+                            file.Replace(sourceDirectoryPath, "").Replace(subDirectories[i] + "\\", ""));
+
+                        cfsiStream.Write(BitConverter.GetBytes((uint)(relativeDataOffset / 16)));
+
+                        int fileSize = CFSI_Util.CFSI_ShouldBeCompressed(file)
+                            ? CFSI_Util.CFSI_Get_Compressed_Size(file)
+                            : CFSI_Util.CFSI_Get_Size(file);
+
+                        cfsiStream.Write(BitConverter.GetBytes((uint)fileSize));
+                        relativeDataOffset += CFSI_Util.CFSI_Get_Aligned(fileSize);
+                    }
+                    relativeDataOffset = CFSI_Util.CFSI_Get_Aligned(relativeDataOffset);
                 }
 
-                long currentPos = cfsiStream.Position;
-                long dataSection = CFSI_Util.CFSI_Get_Aligned(currentPos);
+                long dataSection = CFSI_Util.CFSI_Get_Aligned(cfsiStream.Position);
 
-                if (currentPos < dataSection)
+                for (int i = 0; i < filePathsReordered.Count; i++)
                 {
-                    byte[] padding = new byte[dataSection - currentPos];
-                    cfsiStream.Write(padding, 0, padding.Length);
-                }
+                    cfsiStream.Position = dataSection + fileOffsets[i];
 
-                foreach (var file in structure.Files)
-                {
-                    cfsiStream.Position = dataSection + file.Offset;
-                    string filePath = Path.Combine(folderPath, file.Path.Replace("/", "\\"));
-
-                    if (!File.Exists(filePath))
-                        throw new FileNotFoundException($"File not found: {filePath}");
-
-                    byte[] fileData = GetFileDataForRepack(filePath, file);
-                    cfsiStream.Write(fileData, 0, fileData.Length);
-
-                    long fileEnd = dataSection + file.Offset + fileData.Length;
-                    long alignedEnd = CFSI_Util.CFSI_Get_Aligned(fileEnd);
-                    while (cfsiStream.Position < alignedEnd)
-                        cfsiStream.WriteByte(0);
+                    using (Stream fs = CFSI_Util.CFSI_ShouldBeCompressed(filePathsReordered[i])
+                        ? CFSI_Util.CFSI_Get_Compressed(filePathsReordered[i])
+                        : File.OpenRead(filePathsReordered[i]))
+                    {
+                        fs.Seek(0, SeekOrigin.Begin);
+                        fs.CopyTo(cfsiStream);
+                    }
                 }
 
                 long fileLength = cfsiStream.Length;
                 int remainder = (int)(fileLength % 16);
                 if (remainder != 0)
                 {
-                    byte[] padding = new byte[16 - remainder];
-                    cfsiStream.Write(padding, 0, padding.Length);
+                    int paddingNeeded = 16 - remainder;
+                    byte[] padding = new byte[paddingNeeded];
+                    cfsiStream.Write(padding, 0, paddingNeeded);
                 }
             }
         }
-
-        private static byte[] GetFileDataForRepack(string filePath, CFSI_File file)
+        public void ExportStructureToJson(string outFolder)
         {
-            if (file.Compressed)
+            GenerateStructureJson(outFolder);
+        }
+        private static byte[] CompressFileData(byte[] data)
+        {
+            using (var compressedStream = new MemoryStream())
             {
-                using var fs = File.OpenRead(filePath);
-                using var compressedStream = CFSI_Util.CFSI_Get_Compressed(fs);
-                byte[] fileData = new byte[compressedStream.Length];
-                compressedStream.Position = 0;
-                compressedStream.Read(fileData, 0, fileData.Length);
-                return fileData;
+                compressedStream.Write(BitConverter.GetBytes((uint)data.Length), 0, 4);
+
+                using (var gzipStream = new System.IO.Compression.GZipStream(compressedStream,
+                    System.IO.Compression.CompressionMode.Compress, true))
+                {
+                    gzipStream.Write(data, 0, data.Length);
+                }
+
+                return compressedStream.ToArray();
+            }
+        }
+
+        private static void WriteNum(BinaryWriter writer, int value)
+        {
+            if (value < 0xF8)
+            {
+                writer.Write((byte)value);
             }
             else
             {
-                return File.ReadAllBytes(filePath);
+                writer.Write((byte)0xFC);
+                writer.Write((ushort)value);
             }
         }
 
-        private static void RebuildHeader(Stream stream, List<CFSI_File> files)
+        private static void WriteString(BinaryWriter writer, string text)
         {
-            var filesByFolder = files.GroupBy(f => Path.GetDirectoryName(f.Path) ?? "").ToList();
-
-            CFSI_Util.Write_CFSI_VINT(stream, (ushort)filesByFolder.Count);
-
-            foreach (var folderGroup in filesByFolder)
+            byte[] bytes = System.Text.Encoding.ASCII.GetBytes(text);
+            if (bytes.Length < 0xF8)
             {
-                string folderName = folderGroup.Key;
-                if (string.IsNullOrEmpty(folderName))
-                    folderName = "\0";
-
-                CFSI_Util.Write_CFSI_String(stream, folderName);
-                CFSI_Util.Write_CFSI_VINT(stream, (ushort)folderGroup.Count());
-
-                foreach (var file in folderGroup)
-                {
-                    CFSI_Util.Write_CFSI_String(stream, file.Name);
-                    stream.Write(BitConverter.GetBytes(file.Offset / 16), 0, 4);
-                    stream.Write(BitConverter.GetBytes(file.Size), 0, 4);
-                }
+                writer.Write((byte)bytes.Length);
             }
+            else
+            {
+                writer.Write((byte)0xFC);
+                writer.Write((ushort)bytes.Length);
+            }
+            writer.Write(bytes);
         }
+    }
 
-        private class StructureData
-        {
-            public long DataSectionStart { get; set; }
-            public List<CFSI_File>? Files { get; set; }
-            public string? FullHeaderBytesBase64 { get; set; }
-        }
+    internal class CfsiStructureInfo
+    {
+        public string? SourceCfsiFile { get; set; }
+        public string? ExtractionDate { get; set; }
+        public int TotalEntries { get; set; }
+        public int ExtractedEntries { get; set; }
+        public CfsiEntryInfo[]? Entries { get; set; }
+    }
+
+    internal class CfsiEntryInfo
+    {
+        public string FullPath { get; set; } = string.Empty;
+        public uint Offset { get; set; }
+        public uint Size { get; set; }
+        public bool Extracted { get; set; }
+        public string OutputPath { get; set; } = string.Empty;
     }
 }

--- a/ZE_CFSI_Lib/CFSI_Lib.cs
+++ b/ZE_CFSI_Lib/CFSI_Lib.cs
@@ -1,16 +1,21 @@
+using System.Text;
+using System.Text.Json;
+
 namespace ZE_CFSI_Lib
 {
-    public class CFSI_Lib
+    public class CFSI_Lib : IDisposable
     {
         public Stream stream;
         public List<CFSI_File> Files = new List<CFSI_File>();
         public long DataSectionStart = 0;
+        private bool _disposed = false;
 
         public CFSI_Lib(Stream newStream)
         {
             stream = newStream;
             ReadHeader();
         }
+
         public CFSI_Lib(string filePath)
         {
             stream = File.OpenRead(filePath);
@@ -19,10 +24,24 @@ namespace ZE_CFSI_Lib
 
         public void Dispose()
         {
-            stream.Dispose();
-            stream.Close();
-            Files.Clear();
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    stream?.Dispose();
+                    stream?.Close();
+                    Files.Clear();
+                }
+                _disposed = true;
+            }
+        }
+
         public byte[] GetFileData(CFSI_File file)
         {
             long filePosition = DataSectionStart + file.Offset;
@@ -59,7 +78,7 @@ namespace ZE_CFSI_Lib
 
         public void ExtractFile(CFSI_File file, string OutFolder)
         {
-            string outPath = Path.Combine(OutFolder, file.Path);  // +file.Path.Replace("/", "\\");
+            string outPath = Path.Combine(OutFolder, file.Path);
             Directory.CreateDirectory(outPath.Replace(file.Name, ""));
             File.WriteAllBytes(outPath, GetFileData(file));
         }
@@ -79,19 +98,43 @@ namespace ZE_CFSI_Lib
 
             for (ushort i = 0; i < numOfFolders; i++)
             {
+                long folderNameStart = stream.Position;
                 string folderName = CFSI_Util.Read_CFSI_String(stream);
 
-                if (folderName.Length == 1 && folderName[0] == (char)0) // For Root folder
+                string originalFolderName = folderName;
+
+                if (folderName.Length == 1 && folderName[0] == (char)0)
                     folderName = "\\";
 
                 uint numOfFiles = CFSI_Util.Read_CFSI_VINT(stream);
 
                 for (ushort a = 0; a < numOfFiles; a++)
                 {
+                    long fileEntryStart = stream.Position;
+
                     string fileName = CFSI_Util.Read_CFSI_String(stream);
-                    uint fileOffset = CFSI_Util.Read_UInt32(stream) * 16;
-                    uint fileSize = CFSI_Util.Read_UInt32(stream);
-                    Files.Add(new CFSI_File(fileName, folderName + fileName, fileOffset, fileSize));
+                    uint originalOffsetValue = CFSI_Util.Read_UInt32(stream);
+                    uint originalSizeValue = CFSI_Util.Read_UInt32(stream);
+
+                    uint fileOffset = originalOffsetValue * 16;
+                    uint fileSize = originalSizeValue;
+
+                    string fullPath = originalFolderName == "\0" ? fileName : originalFolderName + fileName;
+
+                    var file = new CFSI_File(fileName, fullPath, fileOffset, fileSize)
+                    {
+                        OriginalOffsetValue = originalOffsetValue,
+                        OriginalSizeValue = originalSizeValue,
+                        OriginalHeaderPosition = fileEntryStart
+                    };
+
+                    long currentPos = stream.Position;
+                    stream.Position = fileEntryStart;
+                    int headerLength = (int)(currentPos - fileEntryStart);
+                    file.OriginalHeaderBytes = CFSI_Util.Read_ByteArray(stream, headerLength);
+                    stream.Position = currentPos;
+
+                    Files.Add(file);
                 }
             }
 
@@ -105,9 +148,7 @@ namespace ZE_CFSI_Lib
                 stream.Position = DataSectionStart + file.Offset;
 
                 uint uncompressedSize = CFSI_Util.Read_UInt32(stream);
-
                 ushort gzipSignature = CFSI_Util.Read_UInt16(stream);
-
                 file.Compressed = (gzipSignature == 0x8b1f);
             }
         }
@@ -119,70 +160,141 @@ namespace ZE_CFSI_Lib
             if (!folder.EndsWith("\\"))
                 folder += "\\";
 
-            string? SourceDirectoryPath = Directory.GetParent(folder)?.FullName + "\\";
+            string originalCfsiPath = folder.TrimEnd('\\') + ".cfsi";
+            if (!File.Exists(originalCfsiPath))
+            {
+                throw new FileNotFoundException($"Original CFSI file not found: {originalCfsiPath}");
+            }
+
+            using (var originalLib = new CFSI_Lib(originalCfsiPath))
+            {
+                FileStream cfsiStream = new FileStream(outPath, FileMode.Create, FileAccess.Write);
+
+                foreach (var file in originalLib.Files)
+                {
+                    cfsiStream.Write(file.OriginalHeaderBytes);
+                }
+
+                long dataSection = CFSI_Util.CFSI_Get_Aligned(cfsiStream.Position);
+                while (cfsiStream.Position < dataSection)
+                {
+                    cfsiStream.WriteByte(0);
+                }
+
+                foreach (var file in originalLib.Files)
+                {
+                    cfsiStream.Position = dataSection + file.Offset;
+
+                    string filePath = Path.Combine(folder, file.Path.Replace("/", "\\").Replace("\\", Path.DirectorySeparatorChar.ToString()));
+                    if (!File.Exists(filePath))
+                    {
+                        throw new FileNotFoundException($"File not found: {filePath}");
+                    }
+
+                    byte[] fileData;
+                    if (file.Compressed)
+                    {
+                        using var fs = File.OpenRead(filePath);
+                        using var compressedStream = CFSI_Util.CFSI_Get_Compressed(fs);
+                        fileData = new byte[compressedStream.Length];
+                        compressedStream.Position = 0;
+                        compressedStream.Read(fileData, 0, fileData.Length);
+                    }
+                    else
+                    {
+                        fileData = File.ReadAllBytes(filePath);
+                    }
+
+                    cfsiStream.Write(fileData, 0, fileData.Length);
+
+                    long fileEnd = dataSection + file.Offset + fileData.Length;
+                    long alignedEnd = CFSI_Util.CFSI_Get_Aligned(fileEnd);
+                    while (cfsiStream.Position < alignedEnd)
+                    {
+                        cfsiStream.WriteByte(0);
+                    }
+                }
+
+                long fileLength = cfsiStream.Length;
+                int remainder = (int)(fileLength % 16);
+                if (remainder != 0)
+                {
+                    int paddingNeeded = 16 - remainder;
+                    byte[] padding = new byte[paddingNeeded];
+                    cfsiStream.Write(padding, 0, paddingNeeded);
+                }
+
+                cfsiStream.Close();
+                cfsiStream.Dispose();
+            }
+        }
+
+        public void RepackWithOriginalStructure(string outPath, string modifiedFolder)
+        {
+            if (!modifiedFolder.EndsWith("\\"))
+                modifiedFolder += "\\";
 
             FileStream cfsiStream = new FileStream(outPath, FileMode.Create, FileAccess.Write);
-            List<string> SubDirectories = new List<string>();
-            List<List<string>> SubDirectoriesFiles = new List<List<string>>();
-            List<string> FilePaths = Directory.GetFiles(folder, "*", new EnumerationOptions() { RecurseSubdirectories = true }).Select(fn => fn).OrderBy(f => CFSI_Util.CFSI_Get_FolderPath(SourceDirectoryPath, f)).ToList();
-            List<string> FilePaths_Reordered = new List<string>();
-            List<long> FileOffsets = new List<long>();
 
-            MemoryStream dataStream = new MemoryStream();
+            stream.Seek(0, SeekOrigin.Begin);
 
-            foreach (var file in FilePaths)
+            long headerEnd = DataSectionStart;
+            byte[] headerData = new byte[headerEnd];
+            stream.Read(headerData, 0, (int)headerEnd);
+
+            cfsiStream.Write(headerData, 0, headerData.Length);
+
+            long currentPos = cfsiStream.Position;
+            long dataSection = CFSI_Util.CFSI_Get_Aligned(currentPos);
+
+            if (currentPos < dataSection)
             {
-                string folderPath = CFSI_Util.CFSI_Get_FolderPath(SourceDirectoryPath, file);
-
-                if (!SubDirectories.Contains(folderPath))
-                {
-                    SubDirectories.Add(folderPath);
-                    SubDirectoriesFiles.Add(new List<string>());
-                }
-                SubDirectoriesFiles[SubDirectories.IndexOf(folderPath)].Add(file);
+                byte[] padding = new byte[dataSection - currentPos];
+                cfsiStream.Write(padding, 0, padding.Length);
             }
 
-            FilePaths.Clear();
-
-            CFSI_Util.Write_CFSI_VINT(cfsiStream, (ushort)SubDirectories.Count);
-
-            int relative_data_offset = 0;
-
-            for (int i = 0; i < SubDirectories.Count; i++)
+            foreach (var file in Files)
             {
-                string folderPath = SubDirectories[i].Replace(SourceDirectoryPath, "");
-                if (!folderPath.EndsWith("\\") && !folderPath.EndsWith("/"))
-                {
-                    folderPath += "/";
-                }
-                CFSI_Util.Write_CFSI_String(cfsiStream, folderPath);
-                CFSI_Util.Write_CFSI_VINT(cfsiStream, (ushort)SubDirectoriesFiles[i].Count);
+                cfsiStream.Position = dataSection + file.Offset;
 
-                foreach (var file in SubDirectoriesFiles[i])
+                string filePath = Path.Combine(modifiedFolder, file.Path.Replace("/", "\\").Replace("\\", Path.DirectorySeparatorChar.ToString()));
+                if (!File.Exists(filePath))
                 {
-                    FilePaths_Reordered.Add(file);
-                    FileOffsets.Add(relative_data_offset);
-                    CFSI_Util.Write_CFSI_String(cfsiStream, file.Replace(SourceDirectoryPath, "").Replace(SubDirectories[i] + "\\", ""));
-                    cfsiStream.Write(BitConverter.GetBytes(relative_data_offset / 16));
-                    int fileSize = (CFSI_Util.CFSI_ShouldBeCompressed(file)) ? CFSI_Util.CFSI_Get_Compressed_Size(file) : CFSI_Util.CFSI_Get_Size(file);
-                    cfsiStream.Write(BitConverter.GetBytes(fileSize));
-                    relative_data_offset += CFSI_Util.CFSI_Get_Aligned(fileSize);
+                    throw new FileNotFoundException($"File not found: {filePath}");
                 }
-                relative_data_offset = CFSI_Util.CFSI_Get_Aligned(relative_data_offset);
-            }
-            long dataSection = CFSI_Util.CFSI_Get_Aligned(cfsiStream.Position);
-            for (int i = 0; i < FilePaths_Reordered.Count; i++)
-            {
-                cfsiStream.Position = dataSection + FileOffsets[i];
 
-                Stream fs;
-                if (CFSI_Util.CFSI_ShouldBeCompressed(FilePaths_Reordered[i]))
-                    fs = CFSI_Util.CFSI_Get_Compressed(FilePaths_Reordered[i]);
+                byte[] fileData;
+                if (file.Compressed)
+                {
+                    using var fs = File.OpenRead(filePath);
+                    using var compressedStream = CFSI_Util.CFSI_Get_Compressed(fs);
+                    fileData = new byte[compressedStream.Length];
+                    compressedStream.Position = 0;
+                    compressedStream.Read(fileData, 0, fileData.Length);
+
+                    if (fileData.Length > file.Size + 1024)
+                    {
+                        Console.WriteLine($"Warning: File {file.Name} compressed size ({fileData.Length}) may exceed original size ({file.Size})");
+                    }
+                }
                 else
-                    fs = File.OpenRead(FilePaths_Reordered[i]);
-                fs.Seek(0, SeekOrigin.Begin);
-                fs.CopyTo(cfsiStream);
-                fs.Dispose(); fs.Close();
+                {
+                    fileData = File.ReadAllBytes(filePath);
+
+                    if (fileData.Length != file.Size)
+                    {
+                        Console.WriteLine($"Warning: File {file.Name} size mismatch (current: {fileData.Length}, original: {file.Size})");
+                    }
+                }
+
+                cfsiStream.Write(fileData, 0, fileData.Length);
+
+                long fileEnd = dataSection + file.Offset + fileData.Length;
+                long alignedEnd = CFSI_Util.CFSI_Get_Aligned(fileEnd);
+                while (cfsiStream.Position < alignedEnd)
+                {
+                    cfsiStream.WriteByte(0);
+                }
             }
 
             long fileLength = cfsiStream.Length;
@@ -196,6 +308,201 @@ namespace ZE_CFSI_Lib
 
             cfsiStream.Close();
             cfsiStream.Dispose();
+        }
+
+        public void ExportStructureToJson(string jsonPath)
+        {
+            var options = new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                IncludeFields = true
+            };
+
+            stream.Seek(0, SeekOrigin.Begin);
+            byte[] fullHeader = CFSI_Util.Read_ByteArray(stream, (int)DataSectionStart);
+
+            var exportData = new
+            {
+                DataSectionStart = this.DataSectionStart,
+                Files = this.Files,
+                FullHeaderBytesBase64 = Convert.ToBase64String(fullHeader)
+            };
+
+            string json = JsonSerializer.Serialize(exportData, options);
+            File.WriteAllText(jsonPath, json);
+        }
+
+        public static void RepackFromJson(string folderPath, string jsonPath, string outPath)
+        {
+            if (!Directory.Exists(folderPath))
+                throw new DirectoryNotFoundException($"Folder not found: {folderPath}");
+
+            if (!File.Exists(jsonPath))
+                throw new FileNotFoundException($"JSON file not found: {jsonPath}");
+
+            string jsonContent = File.ReadAllText(jsonPath);
+            var options = new JsonSerializerOptions { IncludeFields = true };
+            var structure = JsonSerializer.Deserialize<StructureData>(jsonContent, options);
+
+            if (structure == null || structure.Files == null)
+                throw new InvalidDataException("Invalid JSON structure");
+
+            using (FileStream cfsiStream = new FileStream(outPath, FileMode.Create, FileAccess.Write))
+            {
+                if (!string.IsNullOrEmpty(structure.FullHeaderBytesBase64))
+                {
+                    byte[] fullHeaderBytes = Convert.FromBase64String(structure.FullHeaderBytesBase64);
+                    cfsiStream.Write(fullHeaderBytes, 0, fullHeaderBytes.Length);
+                }
+                else if (structure.FullHeaderBytes != null && structure.FullHeaderBytes.Length > 0)
+                {
+                    cfsiStream.Write(structure.FullHeaderBytes, 0, structure.FullHeaderBytes.Length);
+                }
+                else
+                {
+                    RebuildHeader(cfsiStream, structure.Files);
+                }
+
+                long currentPos = cfsiStream.Position;
+                long dataSection = CFSI_Util.CFSI_Get_Aligned(currentPos);
+
+                if (currentPos < dataSection)
+                {
+                    byte[] padding = new byte[dataSection - currentPos];
+                    cfsiStream.Write(padding, 0, padding.Length);
+                }
+
+                foreach (var file in structure.Files)
+                {
+                    cfsiStream.Position = dataSection + file.Offset;
+                    string filePath = Path.Combine(folderPath, file.Path.Replace("/", "\\"));
+
+                    if (!File.Exists(filePath))
+                        throw new FileNotFoundException($"File not found: {filePath}");
+
+                    byte[] fileData = GetFileDataForRepack(filePath, file);
+                    cfsiStream.Write(fileData, 0, fileData.Length);
+
+                    long fileEnd = dataSection + file.Offset + fileData.Length;
+                    long alignedEnd = CFSI_Util.CFSI_Get_Aligned(fileEnd);
+                    while (cfsiStream.Position < alignedEnd)
+                        cfsiStream.WriteByte(0);
+                }
+
+                long fileLength = cfsiStream.Length;
+                int remainder = (int)(fileLength % 16);
+                if (remainder != 0)
+                {
+                    byte[] padding = new byte[16 - remainder];
+                    cfsiStream.Write(padding, 0, padding.Length);
+                }
+            }
+        }
+
+        private static byte[] GetFileDataForRepack(string filePath, CFSI_File file)
+        {
+            if (file.Compressed)
+            {
+                using var fs = File.OpenRead(filePath);
+                using var compressedStream = CFSI_Util.CFSI_Get_Compressed(fs);
+                byte[] fileData = new byte[compressedStream.Length];
+                compressedStream.Position = 0;
+                compressedStream.Read(fileData, 0, fileData.Length);
+                return fileData;
+            }
+            else
+            {
+                return File.ReadAllBytes(filePath);
+            }
+        }
+
+        private static void RebuildHeader(Stream stream, List<CFSI_File> files)
+        {
+            var filesByFolder = new Dictionary<string, List<CFSI_File>>();
+
+            foreach (var file in files)
+            {
+                string folderPath = ExtractOriginalFolderPath(file.Path);
+
+                if (!filesByFolder.ContainsKey(folderPath))
+                    filesByFolder[folderPath] = new List<CFSI_File>();
+
+                filesByFolder[folderPath].Add(file);
+            }
+
+            WriteCorrectVINT(stream, (ushort)filesByFolder.Count);
+
+            foreach (var folderPair in filesByFolder)
+            {
+                string folderName = folderPair.Key;
+                var folderFiles = folderPair.Value;
+
+                WriteOriginalFolderString(stream, folderName);
+
+                WriteCorrectVINT(stream, (ushort)folderFiles.Count);
+
+                foreach (var file in folderFiles)
+                {
+                    CFSI_Util.Write_CFSI_String(stream, file.Name);
+
+                    byte[] offsetBytes = BitConverter.GetBytes(file.OriginalOffsetValue);
+                    stream.Write(offsetBytes, 0, 4);
+
+                    byte[] sizeBytes = BitConverter.GetBytes(file.OriginalSizeValue);
+                    stream.Write(sizeBytes, 0, 4);
+                }
+            }
+        }
+
+        private static string ExtractOriginalFolderPath(string filePath)
+        {
+            int lastSlash = filePath.LastIndexOf('/');
+            if (lastSlash == -1) lastSlash = filePath.LastIndexOf('\\');
+
+            if (lastSlash >= 0)
+            {
+                return filePath.Substring(0, lastSlash + 1);
+            }
+
+            return "\0"; 
+        }
+
+        private static void WriteCorrectVINT(Stream stream, ushort num)
+        {
+            if (num < 0xF8)
+            {
+                stream.WriteByte((byte)num);
+            }
+            else
+            {
+                stream.WriteByte(0xFC);
+                byte[] bytes = BitConverter.GetBytes(num);
+                stream.WriteByte(bytes[0]); 
+                stream.WriteByte(bytes[1]); 
+            }
+        }
+
+        private static void WriteOriginalFolderString(Stream stream, string folderName)
+        {
+            if (folderName == "\0")
+            {
+                stream.WriteByte(1);
+                stream.WriteByte(0);
+            }
+            else
+            {
+                byte[] bytes = Encoding.ASCII.GetBytes(folderName);
+                stream.WriteByte((byte)bytes.Length);
+                stream.Write(bytes, 0, bytes.Length);
+            }
+        }
+
+        private class StructureData
+        {
+            public long DataSectionStart { get; set; }
+            public List<CFSI_File>? Files { get; set; }
+            public byte[]? FullHeaderBytes { get; set; }
+            public string? FullHeaderBytesBase64 { get; set; } 
         }
     }
 }


### PR DESCRIPTION
I personally tested the games Zero Escape: Zero Time Dilemma and Re:ZERO -Starting Life in Another World-. Both the voice.cfsi and bgm.cfsi files could be unpacked without issues, but none of the 00000000.cfsi files could be unpacked. After reviewing the BMS script, I made some simple modifications to your code. Now it can fully unpack CFSI files.

As for repacking, the original process did not pad the end of the file with bytes, resulting in a slightly smaller CFSI file. To address this, I added an automatic padding feature with 00 bytes. Now, after unpacking an original CFSI file and repacking it directly, the file size remains exactly the same—not a single byte is missing.